### PR TITLE
Fix FFXIV not launching when computer has been on for longer than ~24.9 days (pass the tick count to FFXIV as an unsigned int)

### DIFF
--- a/launcher/Launcher.cpp
+++ b/launcher/Launcher.cpp
@@ -77,7 +77,7 @@ void CLauncher::Launch(const char* workingDirectory, const char* lobbyHostName, 
 
 	char commandLine[1024];
 	uint32 currentTickCount = GetTickCount();
-	sprintf(commandLine, " T =%d /LANG =en-us /REGION =2 /SERVER_UTC =1356916742 /SESSION_ID =%s", currentTickCount, sessionId);
+	sprintf(commandLine, " T =%u /LANG =en-us /REGION =2 /SERVER_UTC =1356916742 /SESSION_ID =%s", currentTickCount, sessionId);
 
 	char encryptionKey[9];
 	sprintf(encryptionKey, "%0.8x", currentTickCount & ~0xFFFF);


### PR DESCRIPTION
**Please note: This pull request has not been tested as I do not have the correct build environment.** However, the fix is a simple one.

I recently discovered that using Seventh Umbral Launcher to run FFXIV 1.x after a signed overflow of GetTickCount occurs (once the computer has been on for over ~24.9 days) results in the game failing to launch. This bug can be seen in action in this video, which includes a handy display on when the overflow happens: https://youtu.be/eaLcPSpQar4

At first I thought the problem was with the game itself, since I noticed that `ffxivgame.exe` was able to be launched successfully, but after further investigation I think the issue is actually in the Seventh Umbral Launcher instead.

Namely, when the launcher is calculating the parameters to use to launch the game with, the result of GetTickCount is correctly assigned to an unsigned integer, but the use of `%d` rather than `%u` in the `sprintf` call directly afterwards means that we're passing the signed number to ffxivgame.exe, not the unsigned number.

Although I haven't been able to test this, I'm all but certain that this change will fix this bug.